### PR TITLE
feat(config): add quiet option

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -73,12 +73,12 @@ The plugin can be used in plug-n-play mode without any additional configuration.
 |-------------|---------------|----------------------------------------------------------------------------|----------|-----------------|
 | backup-dir  | string        | Directory to backup the original functions in (relative to base directory) | No       | ''              |
 | debug       | boolean       | Enables verbose logging for the plugin                                     | No       | false           |
-| quiet       | boolean       | Disable all logging for the plugin                                         | No       | false           |
 | directories | Array<string> | List of directories to process (relative to base directory)                | No       | [FUNCTIONS_SRC] |
 | exclude     | Array<string> | List of variables to not process                                           | No       | []              |
 | extensions  | Array<string> | List of extensions to process                                              | No       | ["js", "ts"]    |
 | files       | Array<string> | List of files to process (relative to base directory)                      | No       | []              |
 | include     | Array<string> | List of variables to process                                               | No       | []              |
+| quiet       | boolean       | Disable all logging for the plugin                                         | No       | false           |
 
 Note:
 

--- a/readme.md
+++ b/readme.md
@@ -73,6 +73,7 @@ The plugin can be used in plug-n-play mode without any additional configuration.
 |-------------|---------------|----------------------------------------------------------------------------|----------|-----------------|
 | backup-dir  | string        | Directory to backup the original functions in (relative to base directory) | No       | ''              |
 | debug       | boolean       | Enables verbose logging for the plugin                                     | No       | false           |
+| quiet       | boolean       | Disable all logging for the plugin                                         | No       | false           |
 | directories | Array<string> | List of directories to process (relative to base directory)                | No       | [FUNCTIONS_SRC] |
 | exclude     | Array<string> | List of variables to not process                                           | No       | []              |
 | extensions  | Array<string> | List of extensions to process                                              | No       | ["js", "ts"]    |
@@ -96,6 +97,7 @@ The options can be configured only in `netlify.toml` as follows:
   [plugins.inputs]
     backup-dir = ""
     debug = true
+    quiet  = true
     directories = []
     exclude = []
     extensions = ["js", "ts"]

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import type {NetlifyPlugin, NetlifyPluginOptions} from '@netlify/build'
 export default function bundleEnv(inputs : NetlifyPluginOptions<{
   'backup-dir' : string
   debug : boolean
+  quiet : boolean
   directories : Array<string>
   exclude : Array<string>
   extensions : Array<string>
@@ -17,15 +18,19 @@ export default function bundleEnv(inputs : NetlifyPluginOptions<{
   const workingDir = cwd()
   let countFile = 0
   function logDebug(message : string) {
-    if (inputs.debug) {
+    if (inputs.debug && inputs.quiet !== true) {
       console.log(chalk.blue(message))
     }
   }
   function logSuccess(message : string) {
-    console.log(chalk.green(message))
+    if (inputs.quiet !== true) {
+      console.log(chalk.green(message))
+    }
   }
   function logWarn(message : string) {
-    console.log(chalk.yellow(message))
+    if (inputs.quiet !== true) {
+      console.log(chalk.yellow(message))
+    }
   }
   function recursiveProcess(path : string, callback : (pathToProcess : string) => void) {
     logDebug(`recursiveProcess: checking ${path}`)

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,17 +18,17 @@ export default function bundleEnv(inputs : NetlifyPluginOptions<{
   const workingDir = cwd()
   let countFile = 0
   function logDebug(message : string) {
-    if (inputs.debug && inputs.quiet !== true) {
+    if (inputs.debug && !inputs.quiet) {
       console.log(chalk.blue(message))
     }
   }
   function logSuccess(message : string) {
-    if (inputs.quiet !== true) {
+    if (!inputs.quiet) {
       console.log(chalk.green(message))
     }
   }
   function logWarn(message : string) {
-    if (inputs.quiet !== true) {
+    if (!inputs.quiet) {
       console.log(chalk.yellow(message))
     }
   }


### PR DESCRIPTION
Adding a `quiet` option, disabled by default, to suppress all logs from the output because in our case it's polluting the build output making it difficult to read it.

Thanks! 🙏 