### PR TITLE
fix: recursive infinite loop

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -34,7 +34,7 @@ export default function bundleEnv(inputs : NetlifyPluginOptions<{
       readdirSync(path).forEach(newPath => {
         const absolutePath = join(path, newPath)
         logDebug(`recursiveProcess: absolutePath: ${absolutePath}, checking if directory`)
-        recursiveProcess(path, callback)
+        recursiveProcess(absolutePath, callback)
       })
     } else {
       logDebug(`${path} is a file, calling callback`)


### PR DESCRIPTION
Getting an infinite loop with the last release:

```
4:20:06 PM: checking for excluded/included conflict
4:20:06 PM: checking for directories/files conflict
4:20:06 PM: directories and files not provided, adding functions src to directories
4:20:06 PM: processing: pages
4:20:06 PM: absolute path: /opt/build/repo/pages, checking its existence
4:20:06 PM: /opt/build/repo/pages found
4:20:06 PM: recursiveProcess: checking /opt/build/repo/pages
4:20:06 PM: /opt/build/repo/pages is a directory, performing recursive call
4:20:06 PM: recursiveProcess: absolutePath: /opt/build/repo/pages/404.tsx, checking if directory
4:20:06 PM: recursiveProcess: checking /opt/build/repo/pages
4:20:06 PM: /opt/build/repo/pages is a directory, performing recursive call
4:20:06 PM: recursiveProcess: absolutePath: /opt/build/repo/pages/404.tsx, checking if directory
4:20:06 PM: recursiveProcess: checking /opt/build/repo/pages
4:20:06 PM: /opt/build/repo/pages is a directory, performing recursive call
4:20:06 PM: recursiveProcess: absolutePath: /opt/build/repo/pages/404.tsx, checking if directory
4:20:06 PM: recursiveProcess: checking /opt/build/repo/pages
4:20:06 PM: /opt/build/repo/pages is a directory, performing recursive call
4:20:06 PM: recursiveProcess: absolutePath: /opt/build/repo/pages/404.tsx, checking if directory
4:20:06 PM: recursiveProcess: checking /opt/build/repo/pages
```

I believe this should fix it?