### PR TITLE
Escape variable name and value

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -158,7 +158,7 @@ export default function bundleEnv(inputs : NetlifyPluginOptions<{
                     processedVars.push(varName)
                   }
                   logDebug(`writing ${varName} to file`)
-                  return `process.env['${varName}'] = '${env[varName]}'`
+                  return `process.env[${JSON.stringify(String(varName))}] = ${JSON.stringify(String(env[varName]))}`
                 } else {
                   if (!env[varName]) {
                     logWarn(`skipping ${varName} because its value is undefined`)


### PR DESCRIPTION
Before this change, the generated code could contain syntax errors, if the variable name or value contained a single quote character, or backslash character.

This commit escapes both strings to fix this issue.